### PR TITLE
84033 Исправление блокировки при выполнении запросов с долгим ожиданием.

### DIFF
--- a/src/main/java/com/clickhouse/jdbcbridge/JdbcBridgeVerticle.java
+++ b/src/main/java/com/clickhouse/jdbcbridge/JdbcBridgeVerticle.java
@@ -230,7 +230,7 @@ public class JdbcBridgeVerticle extends AbstractVerticle implements ExtensionMan
 
         startServer(config,
                 Utils.loadJsonFromFile(Paths.get(CONFIG_PATH,
-                        Utils.getConfiguration("httpd.json", "HTTPD_CONFIG_FILE", "jdbc-bridge.httpd.config.file"))
+                                Utils.getConfiguration("httpd.json", "HTTPD_CONFIG_FILE", "jdbc-bridge.httpd.config.file"))
                         .toString()));
     }
 
@@ -260,7 +260,7 @@ public class JdbcBridgeVerticle extends AbstractVerticle implements ExtensionMan
         router.route("/metrics").handler(PrometheusScrapingHandler.create());
 
         router.route().handler(ResponseContentTypeHandler.create()).handler(BodyHandler.create())
-            .handler(this::responseHandlers).failureHandler(this::errorHandler);
+                .handler(this::responseHandlers).failureHandler(this::errorHandler);
 
         // stateless endpoints
         router.get("/ping").handler(requestTimeoutHandler).handler(this::handlePing);
@@ -269,11 +269,44 @@ public class JdbcBridgeVerticle extends AbstractVerticle implements ExtensionMan
         router.post("/identifier_quote").produces(RESPONSE_CONTENT_TYPE).handler(requestTimeoutHandler)
                 .handler(this::handleIdentifierQuote);
         router.post("/columns_info").produces(RESPONSE_CONTENT_TYPE).handler(queryTimeoutHandler)
-                .handler(this::handleColumnsInfo);
-        router.post("/").produces(RESPONSE_CONTENT_TYPE).handler(queryTimeoutHandler).blockingHandler(this::handleQuery,
-                SERIAL_MODE);
+                .handler(ctx -> vertx.executeBlocking(promise -> {
+                    try {
+                        handleColumnsInfo(ctx);
+                        promise.complete();
+                    } catch (Exception e) {
+                        promise.fail(e);
+                    }
+                }, false, result -> {
+                    if (result.failed()) {
+                        errorHandler(ctx);
+                    }
+                }));
+        router.post("/").produces(RESPONSE_CONTENT_TYPE).handler(queryTimeoutHandler)
+                .handler(ctx -> vertx.executeBlocking(promise -> {
+                    try {
+                        handleQuery(ctx);
+                        promise.complete();
+                    } catch (Exception e) {
+                        promise.fail(e);
+                    }
+                }, false, result -> {
+                    if (result.failed()) {
+                        errorHandler(ctx);
+                    }
+                }));
         router.post("/write").produces(RESPONSE_CONTENT_TYPE).handler(queryTimeoutHandler)
-                .blockingHandler(this::handleWrite, SERIAL_MODE);
+                .handler(ctx -> vertx.executeBlocking(promise -> {
+                    try {
+                        handleWrite(ctx);
+                        promise.complete();
+                    } catch (Exception e) {
+                        promise.fail(e);
+                    }
+                }, false, result -> {
+                    if (result.failed()) {
+                        errorHandler(ctx);
+                    }
+                }));
 
         log.info("Starting web server...");
         int port = bridgeServerConfig.getInteger("serverPort", DEFAULT_SERVER_PORT);
@@ -317,8 +350,8 @@ public class JdbcBridgeVerticle extends AbstractVerticle implements ExtensionMan
             // More detailed exception logging
             HttpServerResponse response = ctx.response();
             log.error("Caught exception - Type: {}, Message: {}, Response closed: {}, Response ended: {}",
-                     throwable.getClass().getSimpleName(), throwable.getMessage(),
-                     response.closed(), response.ended(), throwable);
+                    throwable.getClass().getSimpleName(), throwable.getMessage(),
+                    response.closed(), response.ended(), throwable);
         });
 
         ctx.next();

--- a/src/main/java/com/clickhouse/jdbcbridge/JdbcBridgeVerticle.java
+++ b/src/main/java/com/clickhouse/jdbcbridge/JdbcBridgeVerticle.java
@@ -268,7 +268,8 @@ public class JdbcBridgeVerticle extends AbstractVerticle implements ExtensionMan
 
         router.post("/identifier_quote").produces(RESPONSE_CONTENT_TYPE).handler(requestTimeoutHandler)
                 .handler(this::handleIdentifierQuote);
-        router.post("/columns_info").produces(RESPONSE_CONTENT_TYPE).handler(queryTimeoutHandler)
+        router.post("/columns_info").produces(RESPONSE_CONTENT_TYPE)
+                .handler(queryTimeoutHandler)
                 .handler(ctx -> vertx.executeBlocking(promise -> {
                     try {
                         handleColumnsInfo(ctx);
@@ -276,12 +277,14 @@ public class JdbcBridgeVerticle extends AbstractVerticle implements ExtensionMan
                     } catch (Exception e) {
                         promise.fail(e);
                     }
-                }, false, result -> {
-                    if (result.failed()) {
-                        errorHandler(ctx);
+                }, SERIAL_MODE, ar -> {
+                    if (ar.failed()) {
+                        ctx.fail(ar.cause());
                     }
                 }));
-        router.post("/").produces(RESPONSE_CONTENT_TYPE).handler(queryTimeoutHandler)
+
+        router.post("/").produces(RESPONSE_CONTENT_TYPE)
+                .handler(queryTimeoutHandler)
                 .handler(ctx -> vertx.executeBlocking(promise -> {
                     try {
                         handleQuery(ctx);
@@ -289,12 +292,14 @@ public class JdbcBridgeVerticle extends AbstractVerticle implements ExtensionMan
                     } catch (Exception e) {
                         promise.fail(e);
                     }
-                }, false, result -> {
-                    if (result.failed()) {
-                        errorHandler(ctx);
+                }, SERIAL_MODE, ar -> {
+                    if (ar.failed()) {
+                        ctx.fail(ar.cause());
                     }
                 }));
-        router.post("/write").produces(RESPONSE_CONTENT_TYPE).handler(queryTimeoutHandler)
+
+        router.post("/write").produces(RESPONSE_CONTENT_TYPE)
+                .handler(queryTimeoutHandler)
                 .handler(ctx -> vertx.executeBlocking(promise -> {
                     try {
                         handleWrite(ctx);
@@ -302,9 +307,9 @@ public class JdbcBridgeVerticle extends AbstractVerticle implements ExtensionMan
                     } catch (Exception e) {
                         promise.fail(e);
                     }
-                }, false, result -> {
-                    if (result.failed()) {
-                        errorHandler(ctx);
+                }, SERIAL_MODE, ar -> {
+                    if (ar.failed()) {
+                        ctx.fail(ar.cause());
                     }
                 }));
 


### PR DESCRIPTION
**Почему так?**
Исходя из описания https://vertx.io/docs/apidocs/io/vertx/core/WorkerExecutor.html
правильнее использовать executeBlocking, т.к. он берет поток из пула, а не блокирует основной поток.
Ранее использовался blockingHandler со вторым параметром (ORDERED), который фактически указывал использовать блокирующий алгоритм.

Простой перенос фикса для #7 ломает сервер, т.к. мы обновляли vertx и Java (API поменялось). 